### PR TITLE
c: specify library in LDLIBS.

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -10,4 +10,4 @@ clean:
 	rm -rf *.dSYM
 
 CPPFLAGS=-Wall -g
-LDFLAGS=-lcouchbase
+LDLIBS=-lcouchbase


### PR DESCRIPTION
LDLIBS tells make to put `-lcouchbase` *after* the source/object files that include them. Otherwise the linker will decide they are not needed.

Reference: https://forums.couchbase.com/t/5899